### PR TITLE
Critical bugfixes and other tentative additions

### DIFF
--- a/.bashpromptrc
+++ b/.bashpromptrc
@@ -1,0 +1,161 @@
+# vim: ft=sh
+
+# FIGMENTIZE: prompt
+#                                          __
+# ______ _______   ____    _____  ______ _/  |_
+# \____ \\_  __ \ /  _ \  /     \ \____ \\   __\
+# |  |_> >|  | \/(  <_> )|  Y Y  \|  |_> >|  |
+# |   __/ |__|    \____/ |__|_|  /|   __/ |__|
+# |__|                         \/ |__|
+
+# file that sets up my flashy bashy prompt
+# This file was taken from
+# https://github.com/goedel-gang/dotfiles/commit/7db604534dc08672d5a6a4a5ca42968ee9398dbc
+# and has had some bits lopped off to make it more stand-alone. See the original
+# for a vi-mode indicator and Git information in the prompt.
+# This one is mostly to provide a prompt with some colours, basic information
+# and an apparix component.
+
+# here follow a set of functions I have defined to compartmentalise my prompt a
+# little. They make heavy use of ANSI terminal codes and \[ \], which are used
+# to make colours/other styling like bolding, and indicate to Bash that they are
+# non-printing, respectively.
+# I have hardcoded all the ANSI escape codes for performance reasons - it seems
+# to offer a speedup of over 50%, which is worthwile. The tput command used to
+# obtain the sequence is also provided as a comment.
+# Vim tput hardcoding macro (acts on next match of $(tput[^)]*)
+# let @q = "/\\$(tput[^)]*)\<CR>ft\"ayi(cgn\<C-r>\<C-r>=system(\"\<C-r>a\")\<CR>\<Esc>"
+# initialise using 0fly$:<C-r><C-r>"<CR>
+# fix escape sequences with :%s/<C-v>x1b/\\e/g (you have to type the proper
+# sequences yourself)
+
+# The two remaining targets for optimisation are probably reducing function
+# overhead (that is, making the whole thing one disgusting, illegible,
+# unmodifiable one-liner) and the apparix_prompt function, which takes a fair
+# amount of time. See prompt_profile() later on.
+
+# function which returns a code to make text green if exit status was
+# successful, and red otherwise. Indicates the value of a non-zero return
+# status. TAKES AN ARGUMENT
+exitstatus_prompt() {
+    if [[ "$1" == 0 ]]; then
+        # echo -n "\[$(tput setaf 2)\]@"
+        echo -n "\[\e[38;5;2m\]@"
+    else
+        # echo -n "\[$(tput setaf 1)\]($1)"
+        echo -n "\[\e[38;5;1m\]($1)"
+    fi
+}
+
+# function to format a nice SHLVL indicating prompt component, to warn about
+# nested shells.
+shlvl_prompt() {
+    if [[ "$SHLVL" = 1 ]]; then
+        # echo -n "\[$(tput setaf 7)\]|"
+        echo -n "\[\e[38;5;7m\]|"
+    else
+        # echo -n "\[$(tput setaf 7)\][$SHLVL]"
+        echo -n "\[\e[38;5;7m\][$SHLVL]"
+    fi
+}
+
+# function which returns red if the user has root privileges, and pink otherwise
+user_prompt() {
+    if [[ $EUID -ne 0 ]]; then
+        # echo -n "\[$(tput setaf 5)\]\u"
+        echo -n "\[\e[38;5;5m\]\u"
+    else
+        # echo -n "\[$(tput setaf 1)\]\1"
+        echo -n "\[\e[38;5;1m\]\1"
+    fi
+}
+
+# function to return the last two components of PWD, stijn style, with some
+# extra formatting.
+# UNUSED: I personally just whack my full PWD into my prompt, with
+# full_dir_prompt
+dir_prompt() {
+    # a little logic to make directory behave correctly in / and /*/, and also
+    # handle home directory with a little extra logic
+    local iz_dir_base="$(basename "$PWD")"
+    local iz_dir_dir="$(basename "$(dirname "$PWD")")"
+    if [[ "$PWD" = "$HOME" ]]; then
+        local iz_dir="~"
+    elif [[ "$(dirname "$PWD")" = "$HOME" ]]; then
+        local iz_dir="~/$iz_dir_base"
+    elif [[ "$iz_dir_base" = "/" ]]; then
+        local iz_dir="/"
+    elif [[ "$iz_dir_dir" = "/" ]]; then
+        local iz_dir="/$iz_dir_base"
+    else
+        local iz_dir="$iz_dir_dir/$iz_dir_base"
+    fi
+    # echo -n "\[$(tput setaf 6)\]$iz_dir"
+    echo -n "\[\e[38;5;6m\]$iz_dir"
+}
+
+# display PWD in full.
+# I prefer this version because
+# 1) I have space to kill as I use a two-line prompt
+# 2) It's much faster - dir_prompt is a performance bottleneck, as profiled
+#    later on
+full_dir_prompt() {
+    # uses dirs +0 to display ~ in place of eg /home/izaak
+    # echo -n "\[$(tput setaf 6)\]$(dirs +0)"
+    echo -n "\[\e[38;5;6m\]$(dirs +0)"
+}
+
+# function to display the host name
+host_prompt() {
+    # echo -n "\[$(tput setaf 3)\]\h"
+    echo -n "\[\e[38;5;3m\]\h"
+}
+
+# function to display an apparix bookmark if you're in one.
+# This is a little bit of a performance bottleneck, as indicated by
+# prompt_profile. As far as I can see there aren't any really trivial
+# optimisations left, and as it stands it's about 2-3 times slower than any
+# other component (ignoring dir_prompt)
+apparix_prompt() {
+    # assume that amibm has empty output if it's unsuccessful, to avoid having
+    # to re-run it
+    local izaak_bm="$(amibm)"
+    if [[ -n "$izaak_bm" ]]; then
+        # echo -n " \[$(tput setaf 4)\]($izaak_bm)"
+        echo -n " \[\e[38;5;4m\]($izaak_bm)"
+    fi
+}
+
+# function to build a pretty looking prompt, inspired by Stijn van Dongen's
+# taste in prompts, but with more colours.
+izaak_prompt() {
+    # it's important that this goes first, in order to get the exit status
+    # before it runs out
+    local IZAAK_EXIT_STATUS="$?"
+    # some prompt-escaped terminal codes for ease of reference
+    # local iz_bold="\[$(tput bold)\]"
+    # local iz_reset="\[$(tput sgr0)\]"
+    local iz_bold="\[\e[1m\]"
+    local iz_reset="\[\e[m\e(B\]"
+    # construct the prompt from all the earlier components
+    local iz_prompt="$iz_bold$(user_prompt)$(exitstatus_prompt "$IZAAK_EXIT_STATUS")$(host_prompt)$(shlvl_prompt)$(full_dir_prompt)$(apparix_prompt)$iz_reset"
+
+    PS1=$'\n'"$iz_prompt"$'\n'" $iz_bold\[\e[38;5;7m\]->$iz_reset "
+}
+
+PROMPT_COMMAND='izaak_prompt'
+
+# small function to do a very simple profile of the different prompt components
+prompt_profile() {
+    LOOPS=200
+    echo "Profiling each component with $LOOPS loops"
+    for component in izaak_prompt user_prompt exitstatus_prompt host_prompt\
+        shlvl_prompt full_dir_prompt dir_prompt apparix_prompt; do
+        echo
+        echo -n "$component..."
+        time for ((i=0; i<LOOPS; i++)); do
+            # mock some arguments for the component that want them
+            silent "$component" 1 1
+        done
+    done
+}

--- a/.bashpromptrc
+++ b/.bashpromptrc
@@ -24,7 +24,7 @@
 # to offer a speedup of over 50%, which is worthwile. The tput command used to
 # obtain the sequence is also provided as a comment.
 # Vim tput hardcoding macro (acts on next match of $(tput[^)]*)
-# let @q = "/\\$(tput[^)]*)\<CR>ft\"ayi(cgn\<C-r>\<C-r>=system(\"\<C-r>a\")\<CR>\<Esc>"
+# :let @q = "/\\$(tput[^)]*)\<CR>ft\"ayi(cgn\<C-r>\<C-r>=system(\"\<C-r>a\")\<CR>\<Esc>"
 # initialise using 0fly$:<C-r><C-r>"<CR>
 # fix escape sequences with :%s/<C-v>x1b/\\e/g (you have to type the proper
 # sequences yourself)

--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,2 @@
+source .bourne-apparish
+source .bashpromptrc

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -118,9 +118,9 @@
 # TODO: allow commas and newlines in directory names
 
 APPARIXHOME="${APPARIXHOME:=$HOME}"
-APPARIXRC="$APPARIXHOME/.apparixrc"
-APPARIXEXPAND="$APPARIXHOME/.apparixexpand"
-APPARIXLOG="$APPARIXHOME/.apparixlog"
+APPARIXRC="${APPARIXRC:=$APPARIXHOME/.apparixrc}"
+APPARIXEXPAND="${APPARIXRC:=$APPARIXHOME/.apparixexpand}"
+APPARIXLOG="${APPARIXLOG:=$APPARIXHOME/.apparixlog}"
 
 APPARIX_FILE_FUNCTIONS=( a ae av aget toot apparish ) # Huffman (remove a)
 APPARIX_DIR_FUNCTIONS=( to als ald amd todo rme )

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -281,13 +281,13 @@ function portal-expand() {
     grep '^e,' "$APPARIXRC" | cut -f 2 -d , | \
         while read -r parentdir; do
             cd "$parentdir" || return 1
-            # this would be a more complicated alternative for if the number of
-            # files is greater than ARGMAX or whatever. Either approach is
-            # resistant to weird filenames.
-            # find . -maxdepth 1 -mindepth 1 -type d -printf "%f\0" | \
-            # while IFS='' read -r -d '' subdir; do ...; done
-            for _subdir in */ .*/; do
-                local subdir="${_subdir%/}"
+            # this breaks on empty globs. Could set nullglob but that sounds
+            # complicated. Also this might break if there are too many to fit in
+            # ARGMAX
+            # for _subdir in */ .*/; do
+
+            find . -maxdepth 1 -mindepth 1 -type d -printf "%f\0" | \
+            while IFS='' read -r -d '' subdir; do
                 echo "j,$subdir,$parentdir/$subdir" >> "$APPARIXEXPAND"
             done
         done

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -497,19 +497,18 @@ if [[ -n "$BASH_VERSION" ]]; then
     # generate completions for a bookmark
     # this is currently case sensitive. Good? Bad? Who knows!
     function _apparix_compgen_bm() {
+        cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND" | sort |\
+            \grep "^$(grepsanitise "$1")"
         if [[ -n "$1" ]]; then
             cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND" | sort |\
-                \grep "^$(grepsanitise "$1")"
+                \grep "^..*$(grepsanitise "$1")"
         fi
-        cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND" | sort |\
-            \grep "^..*$(grepsanitise "$1")"
     }
 
     # complete an apparix tag followed by a file inside that tag's
     # directory
     function _apparix_comp() {
         local tag="${COMP_WORDS[1]}"
-        local IFS=$'\n'
         COMPREPLY=()
         if [[ "$COMP_CWORD" == 1 ]]; then
             read_array <(_apparix_compgen_bm "$tag")
@@ -539,8 +538,14 @@ if [[ -n "$BASH_VERSION" ]]; then
     # nospace prevents bash putting a space after partially completed paths
     # nosort prevents bash from messing up the bespoke order in which bookmarks
     # are completed
-    complete -o nospace -o nosort -F _apparix_comp \
-        "${APPARIX_FILE_FUNCTIONS[@]}" "${APPARIX_DIR_FUNCTIONS[@]}"
+    if version_assert 4 4 0; then
+        complete -o nospace -o nosort -F _apparix_comp \
+            "${APPARIX_FILE_FUNCTIONS[@]}" "${APPARIX_DIR_FUNCTIONS[@]}"
+    else
+        >&2 echo "(Apparish: Can't disable alphabetic sorting of completions)"
+        complete -o nospace -F _apparix_comp \
+            "${APPARIX_FILE_FUNCTIONS[@]}" "${APPARIX_DIR_FUNCTIONS[@]}"
+    fi
 
 elif [[ -n "$ZSH_VERSION" ]]; then
     function _apparix_file() {

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -2,7 +2,7 @@
 # vim: ft=sh ts=4 sw=0 sts=-1 et
 
 # ignore errors about:
-# - testing $?, becuase that's useful when you have branches
+# - testing $?, because that's useful when you have branches
 # - declaring and assigning at the same time because I know what I'm doing
 #   (fingers crossed)
 # - unexpanded substitutions in single quotes for similar reasons

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -489,7 +489,7 @@ if [[ -n "$BASH_VERSION" ]]; then
         if [[ "$COMP_CWORD" == 1 ]]; then
             read_array <(cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND")
             local tags=( "${izaak_array[@]}" )
-            read_array <(compgen -W "${tags[*]}" -- "$tag")
+            read_array <(compgen -W "${tags[*]}" | grep -F "$tag")
             COMPREPLY=( "${izaak_array[@]}" )
         else
             local cur_file="${COMP_WORDS[2]}"

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -116,6 +116,9 @@
  #
 
 # TODO: allow commas and newlines in directory names
+# TODO: maybe write these as scripts with shebangs, and keep shell functions to
+# very hollow wrapper, to prevent the constant checks for bash/zsh and make it
+# easier to extend to other shells.
 
 APPARIXHOME="${APPARIXHOME:=$HOME}"
 APPARIXRC="${APPARIXRC:=$APPARIXHOME/.apparixrc}"
@@ -281,7 +284,7 @@ function portal-expand() {
     grep '^e,' "$APPARIXRC" | cut -f 2 -d , | \
         while read -r parentdir; do
             cd "$parentdir" || return 1
-            # This depends on GNU find's printf
+            # This unfortunately depends on GNU find's printf
             # find . -maxdepth 1 -mindepth 1 -type d -printf "%f\0" | \
             # while IFS='' read -r -d '' subdir; do
             #     echo "j,$subdir,$parentdir/$subdir" >> "$APPARIXEXPAND"

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -480,6 +480,15 @@ if [[ -n "$BASH_VERSION" ]]; then
         fi
     }
 
+    # generate completions for a bookmark
+    # this is currently case sensitive. Good? Bad? Who knows!
+    function _apparix_compgen_bm() {
+        cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND" | sort |\
+            \grep "^$(grepsanitise "$1")"
+        cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND" | sort |\
+            \grep "^..*$(grepsanitise "$1")"
+    }
+
     # complete an apparix tag followed by a file inside that tag's
     # directory
     function _apparix_comp() {
@@ -487,9 +496,7 @@ if [[ -n "$BASH_VERSION" ]]; then
         local IFS=$'\n'
         COMPREPLY=()
         if [[ "$COMP_CWORD" == 1 ]]; then
-            read_array <(cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND")
-            local tags=( "${izaak_array[@]}" )
-            read_array <(compgen -W "${tags[*]}" | grep -F "$tag")
+            read_array <(_apparix_compgen_bm "$tag")
             COMPREPLY=( "${izaak_array[@]}" )
         else
             local cur_file="${COMP_WORDS[2]}"
@@ -513,8 +520,11 @@ if [[ -n "$BASH_VERSION" ]]; then
     }
 
     # register completions
-    complete -o nospace -F _apparix_comp "${APPARIX_FILE_FUNCTIONS[@]}" \
-                                         "${APPARIX_DIR_FUNCTIONS[@]}"
+    # nospace prevents bash putting a space after partially completed paths
+    # nosort prevents bash from messing up the bespoke order in which bookmarks
+    # are completed
+    complete -o nospace -o nosort -F _apparix_comp \
+        "${APPARIX_FILE_FUNCTIONS[@]}" "${APPARIX_DIR_FUNCTIONS[@]}"
 
 elif [[ -n "$ZSH_VERSION" ]]; then
     function _apparix_file() {

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -119,7 +119,7 @@
 
 APPARIXHOME="${APPARIXHOME:=$HOME}"
 APPARIXRC="${APPARIXRC:=$APPARIXHOME/.apparixrc}"
-APPARIXEXPAND="${APPARIXRC:=$APPARIXHOME/.apparixexpand}"
+APPARIXEXPAND="${APPARIXEXPAND:=$APPARIXHOME/.apparixexpand}"
 APPARIXLOG="${APPARIXLOG:=$APPARIXHOME/.apparixlog}"
 
 APPARIX_FILE_FUNCTIONS=( a ae av aget toot apparish ) # Huffman (remove a)
@@ -270,12 +270,13 @@ function to() {
 }
 
 function portal() {
-   echo "e,$PWD" >> "$APPARIXRC"
-   portal-expand
+    echo "e,$PWD" >> "$APPARIXRC"
+    portal-expand
 }
 
 function portal-expand() {
     local parentdir subdir
+    rm -f "$APPARIXEXPAND"
     true > "$APPARIXEXPAND"
     grep '^e,' "$APPARIXRC" | cut -f 2 -d , | \
         while read -r parentdir; do
@@ -289,7 +290,7 @@ function portal-expand() {
                 local subdir="${_subdir%/}"
                 echo "j,$subdir,$parentdir/$subdir" >> "$APPARIXEXPAND"
             done
-    done
+        done
 }
 
 function whence() {

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -281,15 +281,28 @@ function portal-expand() {
     grep '^e,' "$APPARIXRC" | cut -f 2 -d , | \
         while read -r parentdir; do
             cd "$parentdir" || return 1
-            # this breaks on empty globs. Could set nullglob but that sounds
-            # complicated. Also this might break if there are too many to fit in
-            # ARGMAX
-            # for _subdir in */ .*/; do
+            # This depends on GNU find's printf
+            # find . -maxdepth 1 -mindepth 1 -type d -printf "%f\0" | \
+            # while IFS='' read -r -d '' subdir; do
+            #     echo "j,$subdir,$parentdir/$subdir" >> "$APPARIXEXPAND"
+            # done
 
-            find . -maxdepth 1 -mindepth 1 -type d -printf "%f\0" | \
-            while IFS='' read -r -d '' subdir; do
+            # this might break if you have more directories than ARGMAX
+            # run in subshell to locally set nullglob
+            (
+            if [[ -n "$BASH_VERSION" ]]; then
+                shopt -s nullglob
+                shopt -u dotglob
+                shopt -u failglob
+                GLOBIGNORE=".:.."
+            elif [[ -n "$ZSH_VERSION" ]]; then
+                setopt nullglob
+            fi
+            for _subdir in */ .*/; do
+                local subdir="${_subdir%/}"
                 echo "j,$subdir,$parentdir/$subdir" >> "$APPARIXEXPAND"
             done
+            )
         done
 }
 

--- a/.bourne-apparish
+++ b/.bourne-apparish
@@ -483,8 +483,10 @@ if [[ -n "$BASH_VERSION" ]]; then
     # generate completions for a bookmark
     # this is currently case sensitive. Good? Bad? Who knows!
     function _apparix_compgen_bm() {
-        cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND" | sort |\
-            \grep "^$(grepsanitise "$1")"
+        if [[ -n "$1" ]]; then
+            cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND" | sort |\
+                \grep "^$(grepsanitise "$1")"
+        fi
         cut -f2 -d, "$APPARIXRC" "$APPARIXEXPAND" | sort |\
             \grep "^..*$(grepsanitise "$1")"
     }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 ## Apparix
 
-Completion functions for bash and zsh in `.bourne-apparix`.
+Directory bookmarking system. It used to be implemented in C, shipped with bash
+wrapper functions and completion code. This is now legacy, but it is provided in
+`.bourne_apparix`.
+
+The new pure shell implementation is in `.bourne-apparish`.
+
+There is also a reference prompt that can talk to apparix, if you've got it set
+up, in `.bashpromptrc`.
 
 ## bash-myutils
 
@@ -10,7 +17,7 @@ Small functions that I use in `.bash-myutils`.
 
 ## bash-workutils
 
-Space/time bash functions in `.bourne-apparix`. Most of these will lead to a lot
+Space/time bash functions in `.bash-workutils`. Most of these will lead to a lot
 of disk access, use with care.
 
 


### PR DESCRIPTION
This re-implements the old way of completing on infixes of bookmarks, as requested in #3. It now completes on first prefixes and then infixes, in that order (if your bash supports `complete -o nosort`, otherwise they're all jumbled together alphabetically).

It also fixes some of the more egregious bugs I introduced in #2, including but not limited to totally breaking portals, which hopefully now roughly work once more. I think a possible next step is to turn some of the functions, like `portal-expand` and `apparish` into scripts with shebangs, so that `bourne-apparish` takes on more of a wrapper role again. This would make the whole system more portable between shells.

I also fixed some bits of the README that seemed off. Possibly the other files in the repository also deserve a sentence or two.

Lastly, I've added a bash prompt. It's currently a variation on my own hugely bloated, disgustingly colourful prompt, which needn't be permanent, but I think it would be a nice idea to bundle a prompt that understands apparix.